### PR TITLE
Use quotes instead of brackets for stdtype.h

### DIFF
--- a/gensqu_dec.c
+++ b/gensqu_dec.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 
 static void DecompressFile(UINT32 inLen, const UINT8* inData, const char* fileName);

--- a/kenji_dec.c
+++ b/kenji_dec.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 
 static UINT8 DetectFileType(UINT32 fileSize, const UINT8* fileData, const char* fileName);

--- a/rekiai_dec.c
+++ b/rekiai_dec.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 
 static const char* GetFileExt(const char* filePath);

--- a/wolfteam_dec.c
+++ b/wolfteam_dec.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 
 // Byte Order constants

--- a/x68k_sps_dec.c
+++ b/x68k_sps_dec.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdtype.h>
+#include "stdtype.h"
 
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Since `stdtype.h` isn't in the system include paths, my compiler (`clang`) refuses to use it when it's `#include`d via brackets. This switches every time it's referenced to use quotes instead.